### PR TITLE
Error handling at the adapter level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name":           "polyclay-redis",
-	"version":        "0.0.5",
+	"version":        "0.0.6",
 	"description":    "redis persistence adapter for polyclay, the schema-enforcing document mapper",
 	"author":         "C J Silverio <ceejceej@gmail.com>",
 	"contributors":
@@ -49,6 +49,7 @@
 		"mocha":      "*",
 		"chai":       "*",
 		"blanket":    "*",
+		"sinon":      "*",
 		"travis-cov": "*"
 	},
 	"keywords":


### PR DESCRIPTION
So applications do not need to.

We now handle listening for errors on the redis client & reconnecting if we can. We use an exponential backoff when retrying the connection.

Wrote some unit tests for this feature.
